### PR TITLE
Add Claude Code and repository guidance documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+shell

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- `cmd/`: Go CLI (Cobra + Bubble Tea) logic, installers, helpers, TUI.
+- `main.go`: CLI entrypoint calling `cmd.Execute()`.
+- `assembly/`: Generators for `README.md` and `INSTALL.md`; run to refresh docs.
+- `assets/`: Images used in documentation.
+- `config.toml`: Sync targets (dotfiles) and installer definitions.
+- `packages.toml`: Package groups and per–package metadata.
+- Dotfiles: `git/`, `gnupg/`, `raycast/`, `skhd/`, `tmux/`, `vim/`, `yabai/`, `zsh/`.
+- CI: `.github/workflows/markdown.yml` (docs build) and `deploy.yml` (release build + S3 sync).
+
+## Build, Test, and Development Commands
+- Build releases: `make build` → binaries in `releases/` (Darwin/Linux arches).
+- Clean: `make clean` → remove build artifacts.
+- Run locally (TUI): `go run main.go` (use arrows/enter).
+- Non‑interactive runs: `go run main.go --full` or `go run main.go --vim --tmp`.
+- Docker test harness: `make test -- --zsh` or `make test -- --vim --tmp`.
+- Regenerate docs: `go run assembly/main.go` (updates `README.md`, `INSTALL.md`).
+
+## Coding Style & Naming Conventions
+- Go: follow `gofmt`/idiomatic Go. Run `gofmt -s -w .` before committing.
+- Packages lowercase; exported identifiers `CamelCase`; flags are long `--flag` names.
+- Keep CLI messages concise, present tense. Shell snippets should be POSIX‐sh compatible.
+
+## Testing Guidelines
+- No unit tests yet. If adding tests, use Go’s `testing` with `*_test.go` and run `go test ./...`.
+- Prefer validating flows via non‑interactive flags (examples above). Capture reproducible steps in PRs.
+
+## Commit & Pull Request Guidelines
+- Use clear, scoped commits; Conventional Commits are welcome (e.g., `feat:`, `fix:`, `chore:`).
+- PRs should include: summary, rationale, manual test steps/commands, and linked issues.
+- If you change `config.toml`, `packages.toml`, or `assembly/` templates, run `go run assembly/main.go` and commit regenerated markdown.
+- Include screenshots when altering assets/UI previews. Avoid committing secrets or machine‑specific paths.
+
+## Security & Configuration Tips
+- The installer fetches files and may run package manager commands; review changes carefully.
+- Prefer `--tmp` for ephemeral setups; it writes to `~/.@repo_name.tmp` and includes an uninstall script.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,68 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a Go-based dotfiles management and system configuration tool that provides both interactive (TUI) and non-interactive installation of dotfiles and packages across different Unix-like systems.
+
+## Architecture
+
+### Core Components
+
+- **Main Entry Point**: `main.go` → `cmd.Execute()`
+- **CLI Framework**: Built with Cobra for command handling and Bubble Tea for interactive TUI
+- **Configuration**: TOML-based configuration in `config.toml` defines:
+  - Dotfile sync targets (mapping repo paths to local paths)
+  - Package definitions with package manager mappings (apt, brew, dnf, pacman)
+  - Installer definitions for different components (vim, tmux, zsh)
+
+### Key Modules
+
+- `cmd/root.go`: CLI entry point and flag parsing
+- `cmd/tui.go`: Interactive terminal UI implementation
+- `cmd/installers.go`: Installation logic for packages and dotfiles
+- `cmd/helpers.go`: Utility functions for downloads, command execution, and configuration parsing
+- `assembly/main.go`: Assembly functions for preparing and building the application
+
+## Build and Development Commands
+
+```bash
+# Build the binary
+go build
+
+# Run the binary
+./shell --help
+
+# Test the TUI
+./shell
+
+# Build for release (cross-platform)
+go build -o shell-config-$(uname -s)-$(uname -m)
+```
+
+## Installation Flow
+
+1. User runs `sh <(curl https://marx.sh)` which downloads and executes `install.sh`
+2. `install.sh` fetches the pre-built binary for the user's platform from releases
+3. The binary presents either:
+   - Interactive TUI (default)
+   - Non-interactive installation with flags (`--vim`, `--tmux`, `--zsh`, `--full`)
+4. Selected packages are installed using the system's package manager
+5. Dotfiles are synced from the repo to local paths defined in `config.toml`
+
+## Package Management
+
+The tool supports multiple package managers:
+- **macOS**: Homebrew (brew, brew cask)
+- **Linux**: apt, dnf, pacman
+- **Fallback**: Custom install commands
+
+Package definitions are in `packages.toml` with mappings for each package manager.
+
+## Repository URL Configuration
+
+The repository owner and name are configured in `cmd/helpers.go`:
+- Owner: "williamwmarx"
+- Repo: "shell"
+- These are hard-coded to fix installation issues when running from non-repository directories


### PR DESCRIPTION
## Summary
- Add CLAUDE.md for Claude Code AI assistant guidance
- Add AGENTS.md with comprehensive repository guidelines
- Update .gitignore to exclude built shell binary

## Details
This PR adds two important documentation files to improve development workflow:

### CLAUDE.md
Provides guidance to Claude Code AI assistant when working with this repository, including:
- Project overview and architecture
- Key modules and their responsibilities
- Build and development commands
- Installation flow explanation
- Package management details

### AGENTS.md
Contains comprehensive repository guidelines covering:
- Project structure and module organization
- Build, test, and development commands
- Coding style and naming conventions
- Testing guidelines
- Commit and PR guidelines
- Security and configuration tips

### .gitignore
Added `shell` binary to prevent committing built executables

## Test Plan
- [x] Documentation files are properly formatted in Markdown
- [x] Commands listed in documentation have been verified
- [x] No code changes that require testing